### PR TITLE
 Fix addSex and plotSex

### DIFF
--- a/R/getSex.R
+++ b/R/getSex.R
@@ -13,16 +13,18 @@ getSex <- function(object = NULL, cutoff = -2){
 }
 
 addSex <- function(object, sex = NULL) {
-    if(is.null(sex))
-        sex <- getSex(object)$predictedSex
-    if(is(sex, "DataFrame") && "predictedSex" %in% names(sex))
-        sex <- sex$predictedSex
-    sex <- .checkSex(sex)
-    .pDataAdd(object, DataFrame(predictedSex = sex))
+    if (is.null(sex)) 
+        sex <- getSex(object)
+    if (is(sex, "DataFrame") && "predictedSex" %in% names(sex)) {
+      stopifnot(all(c("predictedSex", "xMed", "yMed") %in% colnames(sex)))
+      sex <- sex[, c("xMed", "yMed", "predictedSex")]
+    }
+    .checkSex(sex$predictedSex)
+    .pDataAdd(object, DataFrame(sex))
 }
 
 plotSex <- function(object, id = NULL) {
-    stopifnot(all(c("predictedSex", "xMed", "yMed") %in% names(object)))
+    stopifnot(all(c("predictedSex", "xMed", "yMed") %in% colnames(pData(object))))
     if(is.null(id))
         id <- 1:length(object$predictedSex)
     if(length(id) != length(object$predictedSex))


### PR DESCRIPTION
`plotSex()` returned an error message `Error: all(c("predictedSex", "xMed", "yMed") %in% names(object)) is not TRUE` when running with the examples, where `addSex()` returned GMsetEx using minfiData example data. It is because the `addSex()` only adds `predictedSex` column but not `xMed` or `yMed`. I fix `addSex()`. 

Another bug is the check point of `names(object)`. As the object is [Genomic]MethylSet, we should use `colnames(pData(object))`.