### PR TITLE
Use DelayedMatrixStats everywhere

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: minfi
-Version: 1.25.2
+Version: 1.25.3
 Title: Analyze Illumina Infinium DNA methylation arrays
 Description: Tools to analyze & visualize Illumina Infinium methylation arrays.
 Authors@R: c(person(c("Kasper", "Daniel"), "Hansen", role = c("cre", "aut"),

--- a/R/compartments.R
+++ b/R/compartments.R
@@ -91,7 +91,7 @@
 
 .removeBadBins <- function(gr) {
     n <- nrow(gr$cor.matrix)
-    good.bins  <- which(colSums(gr$cor.matrix == 0) != n)
+    good.bins <- which(!colAlls(x, value = 0))
     if (length(good.bins) < n) {
         gr <- gr[good.bins]
         gr$cor.matrix <- gr$cor.matrix[, good.bins]
@@ -106,7 +106,7 @@
 
 .getFirstPC <- function(matrix, method){
     # Centre the matrix
-    center <- rowMeans(matrix, na.rm = TRUE)
+    center <- rowMeans2(matrix, na.rm = TRUE)
     matrix <- sweep(matrix, 1L, center, check.margin = FALSE)
     # TODO: Remove commented code if not needed
     ## if(method == "nipals")
@@ -286,7 +286,7 @@ extractAB <- function(gr, keep = TRUE, svdMethod = "qr"){
     pc <- .meanSmoother(pc)
     pc <- .unitarize(pc)
     # Fix sign of eigenvector
-    if (cor(colSums(gr$cor.matrix), pc) < 0 ) {
+    if (cor(colSums2(gr$cor.matrix), pc) < 0 ) {
         pc <- -pc
     }
     pc <- pc * sqrt(length(pc))

--- a/R/compartments.R
+++ b/R/compartments.R
@@ -90,9 +90,8 @@
 }
 
 .removeBadBins <- function(gr) {
-    n <- nrow(gr$cor.matrix)
-    good.bins <- which(!colAlls(x, value = 0))
-    if (length(good.bins) < n) {
+    good.bins <- which(!colAlls(gr$cor.matrix, value = 0))
+    if (length(good.bins) < nrow(gr$cor.matrix)) {
         gr <- gr[good.bins]
         gr$cor.matrix <- gr$cor.matrix[, good.bins]
     }

--- a/R/dmpFinder.R
+++ b/R/dmpFinder.R
@@ -31,8 +31,8 @@ dmpFinder <- function(dat, pheno, type = c("categorical", "continuous"),
                 pval = fit[["F.p.value"]])
         } else {
             fit1 <- lmFit(M)
-            RSS1 <- rowSums((M - fitted(fit1))^2)
-            RSS <- rowSums((M - fitted(fit))^2)
+            RSS1 <- rowSums2((M - fitted(fit1))^2)
+            RSS <- rowSums2((M - fitted(fit))^2)
             df1 <- length(levels(pheno)) - 1
             df2 <- n - length(levels(pheno))
             Fstat <- ((RSS1 - RSS)/df1)/(RSS/df2)

--- a/R/estimateCellCounts.R
+++ b/R/estimateCellCounts.R
@@ -353,9 +353,11 @@ estimateCellCounts <- function(rgSet, compositeCellType = "Blood",
     if (meanPlot) {
         smeans <- compData$sampleMeans
         smeans <- smeans[order(names(smeans))]
-        rows <- match(rownames(coefs), rownames(mSet))
-        sampleMeans <- c(colMeans2(getBeta(mSet), rows = rows), smeans)
-
+        sampleMeans <- c(
+            colMeans2(
+                x = getBeta(mSet),
+                rows = match(rownames(coefs), rownames(mSet))),
+            smeans)
         sampleColors <- c(
             rep(1, ncol(mSet)),
             1 + as.numeric(factor(names(smeans))))

--- a/R/estimateCellCounts.R
+++ b/R/estimateCellCounts.R
@@ -56,7 +56,7 @@ pickCompProbes <- function(mSet, cellTypes = NULL, numProbes = 50,
     trainingProbes <- unique(unlist(probeList))
     p <- p[trainingProbes,]
 
-    pMeans <- colMeans(p)
+    pMeans <- colMeans2(p)
     names(pMeans) <- pd$CellType
 
     form <- as.formula(
@@ -353,7 +353,8 @@ estimateCellCounts <- function(rgSet, compositeCellType = "Blood",
     if (meanPlot) {
         smeans <- compData$sampleMeans
         smeans <- smeans[order(names(smeans))]
-        sampleMeans <- c(colMeans(getBeta(mSet)[rownames(coefs), ]), smeans)
+        rows <- match(rownames(coefs), rownames(mSet))
+        sampleMeans <- c(colMeans2(getBeta(mSet), rows = rows), smeans)
 
         sampleColors <- c(
             rep(1, ncol(mSet)),

--- a/R/gaphunter.R
+++ b/R/gaphunter.R
@@ -26,7 +26,7 @@ gaphunter <- function(object, threshold = 0.05, keepOutliers = FALSE,
                  "(Genomic)MethylSet, or matrix")
         }
     }
-    nacheck <- rowSums(is.na(Beta))
+    nacheck <- rowCounts(Beta, value = NA_real_)
     if (sum(nacheck > 0) > 0) {
         if (verbose) {
             message("[gaphunter] Removing probes containing missing beta ",
@@ -51,7 +51,7 @@ gaphunter <- function(object, threshold = 0.05, keepOutliers = FALSE,
     sortedbeta <- do.call("rbind", lapply(sorting, function(n) n$x))
     rownames(sortedbeta) <- rownames(Beta)
     diffs <- rowDiffs(sortedbeta)
-    gapind <- rowSums(diffs > threshold)
+    gapind <- rowSums2(diffs > threshold)
     sortedindices <- lapply(which(gapind > 0), function(h) sortedindices[[h]])
     sortedbeta <- sortedbeta[which(gapind > 0),]
     diffs <- diffs[which(gapind > 0),]

--- a/R/preprocessFunnorm.R
+++ b/R/preprocessFunnorm.R
@@ -203,7 +203,7 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     ## Bisulfite conversion extraction for probe type II:
     index <- match("BISULFITE CONVERSION II", controlNames)
     redControls.current <- redControls[[ index ]]
-    bisulfite2 <- colMeans(redControls.current, na.rm = TRUE)
+    bisulfite2 <- colMeans2(redControls.current, na.rm = TRUE)
 
     ## Bisulfite conversion extraction for probe type I:
     index <- match("BISULFITE CONVERSION I", controlNames)
@@ -220,9 +220,9 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     }
     redControls.current <- redControls[[ index ]][addr,, drop=FALSE]
     if (nrow(redControls.current)==nrow(greenControls.current)){
-        bisulfite1 <- colMeans(redControls.current + greenControls.current, na.rm = TRUE)
+        bisulfite1 <- colMeans2(redControls.current + greenControls.current, na.rm = TRUE)
     } else {
-        bisulfite1 <- colMeans(redControls.current, na.rm=TRUE) + colMeans(greenControls.current, na.rm = TRUE)
+        bisulfite1 <- colMeans2(redControls.current, na.rm=TRUE) + colMeans2(greenControls.current, na.rm = TRUE)
     }
 
 
@@ -269,8 +269,8 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     colnames(spec2.green) <- paste0("spec2Grn", 1:ncol(spec2.green))
     spec2.red <- t(redControls.current)
     colnames(spec2.red) <- paste0("spec2Red", 1:ncol(spec2.red))
-    spec2.ratio <- colMeans(greenControls.current, na.rm = TRUE) /
-        colMeans(redControls.current, na.rm = TRUE)
+    spec2.ratio <- colMeans2(greenControls.current, na.rm = TRUE) /
+        colMeans2(redControls.current, na.rm = TRUE)
 
     ## Specificity I
     index <- match("SPECIFICITY I", controlNames)
@@ -279,8 +279,8 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     redControls.current <- redControls[[index]][addr,,drop=FALSE]
     spec1.green <- t(greenControls.current)
     colnames(spec1.green) <- paste0("spec1Grn", 1:ncol(spec1.green))
-    spec1.ratio1 <- colMeans(redControls.current, na.rm = TRUE) /
-        colMeans(greenControls.current, na.rm = TRUE)
+    spec1.ratio1 <- colMeans2(redControls.current, na.rm = TRUE) /
+        colMeans2(greenControls.current, na.rm = TRUE)
 
     index <- match("SPECIFICITY I", controlNames) # Added that line
     addr <- getCtrlsAddr(exType = sprintf("GT Mismatch %s (PM)", 4:6), index = index)
@@ -288,19 +288,19 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     redControls.current <- redControls[[index]][addr,,drop=FALSE]
     spec1.red <- t(redControls.current)
     colnames(spec1.red) <- paste0("spec1Red", 1:ncol(spec1.red))
-    spec1.ratio2 <- colMeans(greenControls.current, na.rm = TRUE) /
-        colMeans(redControls.current, na.rm = TRUE)
+    spec1.ratio2 <- colMeans2(greenControls.current, na.rm = TRUE) /
+        colMeans2(redControls.current, na.rm = TRUE)
     spec1.ratio <- (spec1.ratio1 + spec1.ratio2) / 2
 
     ## Normalization probes:
     index <- match(c("NORM_A"), controlNames)
-    normA <- colMeans(redControls[[index]], na.rm = TRUE)
+    normA <- colMeans2(redControls[[index]], na.rm = TRUE)
     index <- match(c("NORM_T"), controlNames)
-    normT <- colMeans(redControls[[index]], na.rm = TRUE)
+    normT <- colMeans2(redControls[[index]], na.rm = TRUE)
     index <- match(c("NORM_C"), controlNames)
-    normC <- colMeans(greenControls[[index]], na.rm = TRUE)
+    normC <- colMeans2(greenControls[[index]], na.rm = TRUE)
     index <- match(c("NORM_G"), controlNames)
-    normG <- colMeans(greenControls[[index]], na.rm = TRUE)
+    normG <- colMeans2(greenControls[[index]], na.rm = TRUE)
 
     dyebias <- (normC + normG)/(normA + normT)
 
@@ -349,7 +349,7 @@ preprocessFunnorm <- function(rgSet, nPCs=2, sex = NULL, bgCorr = TRUE, dyeCorr 
     ## Fixing potential problems with extreme quantiles
     quantiles[1,] <- 0
     quantiles[nrow(quantiles),] <- quantiles[nrow(quantiles) - 1,] + 1000
-    meanFunction <- rowMeans(quantiles)
+    meanFunction <- rowMeans2(quantiles)
     res <- quantiles - meanFunction
     controlPCs <- prcomp(controlMatrix)$x[,1:nPCs,drop=FALSE]
     design <- model.matrix(~controlPCs)

--- a/R/preprocessIllumina.R
+++ b/R/preprocessIllumina.R
@@ -23,8 +23,8 @@ normalize.illumina.control <- function(rgSet, reference = 1) {
             controlType = "Normalization-Green")
     }
 
-    Green.avg <- colMeans(Green[CG.controls, , drop = FALSE])
-    Red.avg <- colMeans(Red[AT.controls, , drop = FALSE])
+    Green.avg <- colMeans2(Green, rows = match(CG.controls, rownames(Green)))
+    Red.avg <- colMeans2(Red, rows = match(AT.controls, rownames(Red)))
     ref <- (Green.avg + Red.avg)[reference] / 2
     if (is.na(ref)) {
         stop("perhaps 'reference' refer to an array that is not present.")

--- a/R/preprocessNoob.R
+++ b/R/preprocessNoob.R
@@ -86,10 +86,12 @@ dyeCorrection <- function(Meth, Unmeth, Red, Green, control_probes,
     }
 
     # Dye bias normalization with the corrected Illumina control probes
-    Green.avg <- colMeans(
-        internal.controls[["Green"]][CG.controls, , drop = FALSE])
-    Red.avg <- colMeans(
-        internal.controls[["Red"]][AT.controls, , drop = FALSE])
+    Green.avg <- colMeans2(
+        x = internal.controls[["Green"]],
+        rows = match(CG.controls, rownames(internal.controls[["Green"]])))
+    Red.avg <- colMeans2(
+        x = internal.controls[["Red"]],
+        rows = match(AT.controls, rownames(internal.controls[["Red"]])))
     R.G.ratio <- Red.avg / Green.avg
 
     if (dyeMethod == "single") {

--- a/R/preprocessSwan.R
+++ b/R/preprocessSwan.R
@@ -17,7 +17,7 @@ bgIntensitySwan <- function(rgSet) {
     redMed <- colMedians(
         x = getRed(rgSet),
         rows = rows)
-    rowMeans(cbind(grnMed, redMed))
+    rowMeans2(cbind(grnMed, redMed))
 }
 
 # TODO: Profile and tidy


### PR DESCRIPTION
WARNING: This will break digest-based tests since this switch incurs numerical differences (https://github.com/hansenlab/minfi/issues/153)

- Use [col|row][Means2|Sums2] everywhere
- Use `rows` and `cols` arguments of  [col|row][Means2|Sums2] instead of 'subset then compute column/row summary'
- Use `!colAlls(x, value = 0)` instead of `colSums(x == 0) != nrow(x)`
- Use `rowCounts(x, value = NA)` instead of `rowSums(is.na(x))`