### PR TITLE
Add DelayedArray support for compartments() and createCorMatrix()

### DIFF
--- a/inst/unitTests/test_compartments.R
+++ b/inst/unitTests/test_compartments.R
@@ -19,16 +19,12 @@ test_compartments <- function() {
     ## # Testing with DelayedArray-backed objects
     ## MsetEx <- realize(MsetEx)
     ## GMsetEx <- mapToGenome(MsetEx)
-    ## checkException(gr.cor <- createCorMatrix(GMsetEx, res = 500*1000),
-    ##                silent = TRUE)
-    ## # TODO: Uncomment once createCorMatrix() supports DelayedArray-backed
-    ## #       minfi objects
-    ## # gr.cor <- createCorMatrix(GMsetEx, res = 500*1000)
-    ## # checkEquals(digest_compartments$cor.matrix,
-    ## #             minfi:::.digestMatrix(gr.cor$cor.matrix))
-    ## # set.seed(456)
-    ## # gr.ab <- extractAB(gr.cor)
-    ## # checkEquals(digest_compartments$pc,
-    ## #             minfi:::.digestVector(gr.ab$pc, digits = 2))
+    ## gr.cor <- createCorMatrix(GMsetEx, res = 500*1000)
+    ## checkEquals(digest_compartments$cor.matrix,
+    ##             minfi:::.digestMatrix(gr.cor$cor.matrix))
+    ## set.seed(456)
+    ## gr.ab <- extractAB(gr.cor)
+    ## checkEquals(digest_compartments$pc,
+    ##             minfi:::.digestVector(gr.ab$pc, digits = 2))
     checkTrue(TRUE)
 }

--- a/man/compartments.Rd
+++ b/man/compartments.Rd
@@ -10,8 +10,8 @@
   eigenvector on a binned probe correlation matrix.
 }
 \usage{
-compartments(object, resolution=100*1000, what = "OpenSea", chr="chr22",
-                  method = c("pearson", "spearman"), keep=TRUE)
+compartments(object, resolution = 100000L, what = "OpenSea", chr = "chr22",
+                  method = c("pearson", "spearman"), keep = TRUE)
 }
 \arguments{
   \item{object}{An object of class (Genomic)MethylSet or (Genomic)RatioSet}


### PR DESCRIPTION
Support is not-fully optimised but should be reasonable since only a small-ish subset of loci are used.

In `createCorMatrix()`, the subsetted `M` matrix, with dimensions = nloci * nsamples, is realized in-memory. This is relatively small since it is restricted to a single chromosome, typically only includes Open Sea probes, and has SNPs removed.

A complete implementation will require `cor()`, `.returnBinnedMatrix()`, `.getFirstPC()`,  `.fsvd()`, `.meanSmoother()`, and `.unitarize()` to support DelayedArray instances.